### PR TITLE
Fix duplicate sequences issue

### DIFF
--- a/src/core/ServerAbrStream.ts
+++ b/src/core/ServerAbrStream.ts
@@ -101,7 +101,10 @@ export class ServerAbrStream extends EventEmitterLike {
             : data.initializedFormats[0];
 
         for (const fmt of data.initializedFormats) {
-          this.previousSequences.set(fmt.formatKey, fmt.sequenceList.map((seq) => seq.sequenceNumber || 0));
+          if (this.previousSequences.has(fmt.formatKey))
+            this.previousSequences.get(fmt.formatKey).push(...fmt.sequenceList.map((seq) => seq.sequenceNumber || 0))
+          else
+            this.previousSequences.set(fmt.formatKey, fmt.sequenceList.map((seq) => seq.sequenceNumber || 0));
         }
 
         if (


### PR DESCRIPTION
In `public async init` method, `this.previousSequences[fmt.formatKey]` doesn't save previous data becouse of `this.previousSequences.set(fmt.formatKey, fmt.sequenceList.map((seq) => seq.sequenceNumber || 0));` (previous data is deleted because set by new array)
So there is duplicate sequences issue, this PR can fix that issue.