### PR TITLE
chore(protos): Add audioTrackId to ClientAbrState

### DIFF
--- a/protos/generated/video_streaming/client_abr_state.ts
+++ b/protos/generated/video_streaming/client_abr_state.ts
@@ -48,6 +48,7 @@ export interface ClientAbrState {
   sabrForceProxima?: number | undefined;
   Tqb?: number | undefined;
   sabrForceMaxNetworkInterruptionDurationMs?: number | undefined;
+  audioTrackId?: string | undefined;
 }
 
 function createBaseClientAbrState(): ClientAbrState {
@@ -90,6 +91,7 @@ function createBaseClientAbrState(): ClientAbrState {
     sabrForceProxima: 0,
     Tqb: 0,
     sabrForceMaxNetworkInterruptionDurationMs: 0,
+    audioTrackId: "",
   };
 }
 
@@ -213,6 +215,9 @@ export const ClientAbrState: MessageFns<ClientAbrState> = {
       message.sabrForceMaxNetworkInterruptionDurationMs !== 0
     ) {
       writer.uint32(544).int64(message.sabrForceMaxNetworkInterruptionDurationMs);
+    }
+    if (message.audioTrackId !== undefined && message.audioTrackId !== "") {
+      writer.uint32(554).string(message.audioTrackId);
     }
     return writer;
   },
@@ -489,6 +494,13 @@ export const ClientAbrState: MessageFns<ClientAbrState> = {
           }
 
           message.sabrForceMaxNetworkInterruptionDurationMs = longToNumber(reader.int64());
+          continue;
+        case 69:
+          if (tag !== 554) {
+            break;
+          }
+
+          message.audioTrackId = reader.string();
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {

--- a/protos/video_streaming/client_abr_state.proto
+++ b/protos/video_streaming/client_abr_state.proto
@@ -40,4 +40,5 @@ message ClientAbrState {
   optional int32 sabr_force_proxima = 66;
   optional int32 Tqb = 67;
   optional int64 sabr_force_max_network_interruption_duration_ms = 68;
+  optional string audio_track_id = 69;
 }


### PR DESCRIPTION
The value for this field comes from `audio_track.id` in YouTube.js' `Format` class.