### PR TITLE
Fix example downloader

### DIFF
--- a/examples/downloader/utils/sabr-stream-factory.ts
+++ b/examples/downloader/utils/sabr-stream-factory.ts
@@ -150,7 +150,7 @@ export async function createSabrStream(
   streamResults: StreamResults;
 }> {
   const innertube = await Innertube.create({ cache: new UniversalCache(true), player_id: '0004de42' });
-  const webPoTokenResult = await generateWebPoToken(innertube.session.context.client.visitorData || '');
+  const webPoTokenResult = await generateWebPoToken(videoId);
 
   // Get video metadata.
   const playerResponse = await makePlayerRequest(innertube, videoId);

--- a/examples/downloader/utils/sabr-stream-factory.ts
+++ b/examples/downloader/utils/sabr-stream-factory.ts
@@ -149,7 +149,7 @@ export async function createSabrStream(
   innertube: Innertube;
   streamResults: StreamResults;
 }> {
-  const innertube = await Innertube.create({ cache: new UniversalCache(true) });
+  const innertube = await Innertube.create({ cache: new UniversalCache(true), player_id: '0004de42' });
   const webPoTokenResult = await generateWebPoToken(innertube.session.context.client.visitorData || '');
 
   // Get video metadata.


### PR DESCRIPTION
Force player id like yt-dlp (https://github.com/yt-dlp/yt-dlp/commit/7f5d9f8543d19590eeec9473d54fa00151afa78a)
GVS PO Token is now bound to videoId (https://github.com/yt-dlp/yt-dlp/commit/bd5ed90419eea18adfb2f0d8efa9d22b2029119f)