### PR TITLE
fix(sabr-shaka-example): remove adPlaybackContext from playbackContext

### DIFF
--- a/examples/downloader/utils/sabr-stream-factory.ts
+++ b/examples/downloader/utils/sabr-stream-factory.ts
@@ -48,7 +48,6 @@ export async function makePlayerRequest(innertube: Innertube, videoId: string, r
 
   const extraArgs: Record<string, any> = {
     playbackContext: {
-      adPlaybackContext: { pyv: true },
       contentPlaybackContext: {
         vis: 0,
         splay: false,

--- a/examples/sabr-shaka-example/src/main.ts
+++ b/examples/sabr-shaka-example/src/main.ts
@@ -129,9 +129,6 @@ async function loadVideo(videoId: string) {
       contentCheckOk: true,
       racyCheckOk: true,
       playbackContext: {
-        adPlaybackContext: {
-          pyv: true
-        },
         contentPlaybackContext: {
           signatureTimestamp: innertube.session.player?.signature_timestamp
         }
@@ -183,9 +180,6 @@ async function loadVideo(videoId: string) {
         contentCheckOk: true,
         racyCheckOk: true,
         playbackContext: {
-          adPlaybackContext: {
-            pyv: true
-          },
           contentPlaybackContext: {
             signatureTimestamp: innertube.session.player?.signature_timestamp
           },


### PR DESCRIPTION
Removed the adPlaybackContext parameter that prevented playback from starting. From what we have seen, this parameter has been patched.